### PR TITLE
Update UI docker image for 1Platform

### DIFF
--- a/nto-deployment.yaml
+++ b/nto-deployment.yaml
@@ -150,7 +150,7 @@ spec:
     spec:
       containers:
       - name: service-mesh-ui
-        image: docker.io/dfoley3118/service-mesh-ui:latest
+        image: docker.io/dfoley3118/service-mesh-ui:working
         ports:
         - containerPort: 3000
 ---


### PR DESCRIPTION
The docker image should be docker.io/dfoley3118/service-mesh-ui:working for 1Platform demo to show NTO eCommerce.